### PR TITLE
feat(epg): reduce program start / end time padding

### DIFF
--- a/src/features/game/game.service.ts
+++ b/src/features/game/game.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
-import { format } from 'date-fns'
+import { add, format } from 'date-fns'
 import { toZonedTime } from 'date-fns-tz'
 
 import { Epg, MastApiService, VideoFeed } from '@/clients/mastapi'
@@ -48,7 +48,7 @@ export class GameService {
           const awayTeam = Object.keys(TeamId)[Object.values(TeamId).indexOf(awayTeamId)] as Team
           const opponent: Team = team === homeTeam ? awayTeam : homeTeam
           const startDate: Date = new Date(gameData.gameDate)
-          const approximateEndDate: Date = new Date(startDate.valueOf() + 3 * 60 * 60 * 1000) // start date + 3 hours
+          const approximateEndDate: Date = add(startDate, { hours: 2, minutes: 40 }) // start date + 2 hours 40 minutes (average MLB game length)
           const zonedStartDate: Date = toZonedTime(startDate, tz)
 
           const epgGames = targetVideoFeeds.map<Game>((videoFeed) => ({

--- a/src/http/guide/guide.service.ts
+++ b/src/http/guide/guide.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import { ConfigService } from '@nestjs/config'
+import { add, sub } from 'date-fns'
 import { format } from 'date-fns-tz'
 
 import { Game, GameService } from '@/features/game'
@@ -19,7 +20,7 @@ export class GuideService {
     const TZ: string = this.config.getOrThrow<string>('TZ')
     const teams = Object.keys(TeamId) as Team[]
     const today: Date = new Date(Date.now())
-    const sevenDaysFromNow: Date = new Date(today.valueOf() + 7 * 24 * 60 * 60 * 1000)
+    const sevenDaysFromNow: Date = add(today, { days: 7 })
 
     const programs: Program[] = (
       await Promise.all<Program[]>(
@@ -27,18 +28,14 @@ export class GuideService {
           const games: Game[] = await this.game.getGamesInRange(team, today, sevenDaysFromNow)
 
           return games.map<Program>((game: Game) => {
-            const startDate: Date = new Date(game.startDate.valueOf() - 60 * 60 * 1000) // start date - 1 hour
-            const stopDate: Date = new Date(game.approximateEndDate.valueOf() + 60 * 60 * 1000) // end date + 1 hour
-            const formattedStartDate: string = format(startDate, 'yyyyMMddHHmmss XXX', { timeZone: TZ }).replace(
-              /:/g,
-              '',
-            )
-            const formattedStopDate: string = format(stopDate, 'yyyyMMddHHmmss XXX', { timeZone: TZ }).replace(/:/g, '')
+            // buffer of 30 minutes before and after the game to account for pre-game and post-game content
+            const programStartDate: Date = sub(game.startDate, { minutes: 30 })
+            const programStopDate: Date = add(game.approximateEndDate, { minutes: 30 })
 
             return {
               game,
-              start: formattedStartDate,
-              stop: formattedStopDate,
+              start: format(programStartDate, 'yyyyMMddHHmmss XXX', { timeZone: TZ }).replace(/:/g, ''),
+              stop: format(programStopDate, 'yyyyMMddHHmmss XXX', { timeZone: TZ }).replace(/:/g, ''),
               team,
             }
           })


### PR DESCRIPTION
### Description

- Reduce program start / end time EPG padding from 1 hr -> 30 min to better account for pre / post game timing
- Decrease approximate game end from game start + 3 hrs to game start + 2 hrs 40 mins (average MLB game length)